### PR TITLE
state->init

### DIFF
--- a/example/editor/EditorApp.js
+++ b/example/editor/EditorApp.js
@@ -31,7 +31,7 @@ function M2V () {
     textarea.value = text.text;
 }
 
-text.on('.state',M2V); // FIXME on('')
+text.on('.init',M2V); // FIXME on('')
 text.on(M2V);
 
 textarea.onkeyup = function textChange(ev) {

--- a/example/mice/MiceApp.js
+++ b/example/mice/MiceApp.js
@@ -30,7 +30,7 @@ var ssnInt = Spec.base2int(ssn);
 
 // create a Mouse object
 var mickey = app.mouse = new Mouse(app.id);
-mickey.on('.state', function () {
+mickey.on('.init', function () {
     if (this._version!=='!0') { return; } // FIXME default values
     mickey.set({
         x:100+(0|(Math.random()*100)),

--- a/lib/FileStorage.js
+++ b/lib/FileStorage.js
@@ -156,10 +156,13 @@ FileStorage.prototype.loadLog = function () {
     }
     var json = fs.readFileSync(this.logFileName(), {encoding:"utf8"});
     if (!json) { return; }
-    if (json.charAt(json.length-1)!=='}') {
-        json = json + '}'; // open-ended JSON
+
+    try {
+        this.tails = JSON.parse(json);
+    } catch (ex) {
+        // open-ended JSON
+        this.tails = JSON.parse(json + '}');
     }
-    this.tails = JSON.parse(json);
     delete this.tails[''];
     for(var s in this.tails) {
         var spec = new Spec(s);

--- a/lib/Host.js
+++ b/lib/Host.js
@@ -100,7 +100,7 @@ module.exports = Syncable.extend(Host, {
             }
             o = new t(typeid, undefined, this);
             if (typeof(callback) === 'function') {
-                o.on('.state', callback);
+                o.on('.init', callback);
             }
         }
         return o;
@@ -128,9 +128,9 @@ module.exports = Syncable.extend(Host, {
          * Host forwards on() calls to local objects to support some
          * shortcut notations, like
          *          host.on('/Mouse',callback)
-         *          host.on('/Mouse.state',callback)
+         *          host.on('/Mouse.init',callback)
          *          host.on('/Mouse#Mickey',callback)
-         *          host.on('/Mouse#Mickey.state',callback)
+         *          host.on('/Mouse#Mickey.init',callback)
          *          host.on('/Mouse#Mickey!baseVersion',repl)
          *          host.on('/Mouse#Mickey!base.x',trackfn)
          * The target object may not exist beforehand.

--- a/lib/Model.js
+++ b/lib/Model.js
@@ -142,7 +142,7 @@ module.exports = Syncable.extend(Model, {
 
         this[key] = this._host.get(spec);
         /* TODO new this.refType(id) || new Swarm.types[type](id);
-         on('state', function(){
+         on('init', function(){
          self.emit('fill',key,this)
          self.emit('full',key,this)
          });*/

--- a/lib/ReactMixin.js
+++ b/lib/ReactMixin.js
@@ -24,7 +24,7 @@ module.exports = {
         this.sync = env.localhost.get(spec);
         this.setState({version:''});
         if (!env.isServer) {
-            this.sync.on('.state', this); // TODO single listener
+            this.sync.on('.init', this); // TODO single listener
             this.sync.on(this);
         }
         /*if (typeof(this.sync.onObjectEvent)==='function') {

--- a/lib/SharedWebStorage.js
+++ b/lib/SharedWebStorage.js
@@ -28,7 +28,7 @@ function SharedWebStorage(usePersistentStorage) {
         }
         //if (self.store.getItem(ev.key)!==ev.newValue) return; // FIXME some hint (conflicts with tail cleanup)
         var spec = new Spec(ev.key);
-        // states and tails are written as /Type#id.state/tail
+        // states and tails are written as /Type#id.init/tail
         // while ops have full /#!. specifiers.
         if (spec.pattern() !== '/#!.') {
             if (spec.pattern() === '/#') {
@@ -90,7 +90,7 @@ SharedWebStorage.prototype.deliver = function (spec, value, src) {
     case 'off':
         return this.off(spec, value, src);
     case 'state':
-        return this.state(spec, value, src);
+        return this.init(spec, value, src);
     default:
         return this.op(spec, value, src);
     }
@@ -105,11 +105,11 @@ SharedWebStorage.prototype.op = function wsOp(spec, value, src) {
     tail.push(vm);
     this.store.setItem(spec, JSON.stringify(value));
     if (tail.length > 5) {
-        src.deliver(spec.set('.on'), '!0.state', this); // request a state
+        src.deliver(spec.set('.on'), '!0.init', this); // request a state
     }
 };
 
-SharedWebStorage.prototype.state = function wsPatch(spec, state, src) {
+SharedWebStorage.prototype.init = function wsPatch(spec, state, src) {
     var ti = spec.filter('/#');
     this.store.setItem(ti, JSON.stringify(state));
     var tail = this.tails[ti];
@@ -146,7 +146,7 @@ SharedWebStorage.prototype.on = function (spec, base, replica) {
         }
     }
 
-    replica.deliver(spec.set('.state'), state || {}, this);
+    replica.deliver(spec.set('.init'), state || {}, this);
 
     var vv = state ? Syncable.stateVersionVector(state) : '!0';
 

--- a/lib/Storage.js
+++ b/lib/Storage.js
@@ -24,8 +24,8 @@ Storage.prototype.deliver = function (spec, value, src) {
         return this.on(spec, value, src);
     case 'off':
         return this.off(spec, value, src);
-    case 'state':
-        return this.state(spec, value, src);
+    case 'init':
+        return this.init(spec, value, src);
     default:
         return this.anyOp(spec, value, src);
     }
@@ -59,7 +59,7 @@ Storage.prototype.on = function storageOn (spec, base, src) {
             }
         }
         var tiv = ti.add(spec.version(), '!');
-        src.deliver(tiv.add('.state'), state, self);
+        src.deliver(tiv.add('.init'), state, self);
         src.deliver(tiv.add('.reon'), Syncable.stateVersionVector(state), self); // TODO and the tail
     }
 
@@ -97,7 +97,7 @@ Storage.prototype.off = function (spec, value, src) {
     }
 };
 
-Storage.prototype.state = function (spec, state, src) {
+Storage.prototype.init = function (spec, state, src) {
     var ti = spec.filter('/#'), self=this;
     var saveops = this.tails[ti];
     delete this.tails[ti];
@@ -128,7 +128,7 @@ Storage.prototype.anyOp = function (spec, value, src) {
         // First, it adds an op to the log tail unless the log is too long...
         // ...otherwise it sends back a subscription effectively requesting
         // the state, on state arrival zeroes the tail.
-        src.deliver(spec.set('.reon'), '.state', self);
+        src.deliver(spec.set('.reon'), '.init', self);
         delete self.counts[ti];
     }
 };

--- a/lib/Syncable.js
+++ b/lib/Syncable.js
@@ -40,7 +40,7 @@ function Syncable() {
     // (while external-id objects need to query uplinks)
     /*if (fresh && state) {
      state._version = '!'+this._id;
-     var pspec = this.spec().add(state._version).add('.state');
+     var pspec = this.spec().add(state._version).add('.init');
      this.deliver(pspec,state,this._host);
      }*/
     // find uplinks, subscribe
@@ -368,7 +368,7 @@ Syncable.extend(Syncable, {  // :P
                 // invoke the implementation
                 this._ops[call].call(this, spec, value, lstn); // NOTE: no return value
                 // once applied, may remember in the log...
-                if (spec.op() !== 'state') {
+                if (spec.op() !== 'init') {
                     this._oplog && (this._oplog[spec.filter('!.')] = value);
                     // this._version is practically a label that lets you know whether
                     // the state has changed. Also, it allows to detect some cases of
@@ -518,7 +518,7 @@ Syncable.extend(Syncable, {  // :P
      */
     isReplay: function (spec) {
         if (!this._version) { return false; }
-        if (spec.op() === 'state') { return false; } // these are .on !vids
+        if (spec.op() === 'init') { return false; } // these are .on !vids
         var opver = spec.version();
         if (opver > this._version.substr(1)) { return false; }
         if (spec.filter('!.').toString() in this._oplog) { return true; }// TODO log trimming, vvectors?
@@ -613,9 +613,9 @@ Syncable.extend(Syncable, {  // :P
                 var baseVersion = filter.get('!'),
                     filter_by_op = filter.get('.');
 
-                if (filter_by_op === 'state') {
+                if (filter_by_op === 'init') {
                     var diff_if_needed = baseVersion ? this.diff(baseVersion) : '';
-                    repl.deliver(spec.set('.state'), diff_if_needed, this); //??
+                    repl.deliver(spec.set('.init'), diff_if_needed, this); //??
                     // use once()
                     return;
                 }
@@ -633,7 +633,7 @@ Syncable.extend(Syncable, {  // :P
 
                 if (baseVersion) {
                     var diff = this.diff(baseVersion);
-                    diff && repl.deliver(spec.set('.state'), diff, this); // 2downlink
+                    diff && repl.deliver(spec.set('.init'), diff, this); // 2downlink
                     repl.deliver(spec.set('.reon'), this.version().toString(), this);
                 }
             }
@@ -654,7 +654,7 @@ Syncable.extend(Syncable, {  // :P
                 return;
             }
             // 2uplink
-            repl.deliver(spec.set('.state'), diff, this);
+            repl.deliver(spec.set('.init'), diff, this);
         },
 
         /** Unsubscribe */
@@ -698,11 +698,11 @@ Syncable.extend(Syncable, {  // :P
          * mainly uses its plain state, but sometimes its log tail as well. The
          * format of the state object is POJO plus (optionally) special fields:
          * _oplog, _tail, _vector, _version (the latter flags POJO presence).
-         * In either case, .state is only produced by diff() (+ by storage).
+         * In either case, .init is only produced by diff() (+ by storage).
          * Any real-time changes are transferred as individual events.
          * @this {Syncable}
          */
-        state: function (spec, state, src) {
+        init: function (spec, state, src) {
 
             var tail = {}, // ops to be applied on top of the received state
                 typeid = spec.filter('/#'),

--- a/lib/Vector.js
+++ b/lib/Vector.js
@@ -90,7 +90,7 @@ module.exports = Syncable.extend('Vector', {
 
     reactions: {
 
-        'state': function fillAll (spec,val,src) { // TODO: reactions, state init tests
+        'init': function fillAll (spec,val,src) { // TODO: reactions, state init tests
             for(var i=this._order.iterator(); !i.end(); i.next()) {
                 var op = i.token() + '.in';
                 var value = this._oplog[op];
@@ -316,19 +316,26 @@ module.exports = Syncable.extend('Vector', {
 
     onObjectStateReady: function (callback) { // TODO timeout ?
         var self = this;
-        var checker = {
-            deliver: function () {
-                for(var i=0; i<self.objects.length; i++) {
-                    var obj = self.objects[i];
-                    if (!obj._version) {
-                        obj.on('.state', checker);
-                        return;
-                    }
+        console.log(this._id + '.onObjectStateReady');
+        function checker() {
+            for(var i = 0; i < self.objects.length; i++) {
+                var obj = self.objects[i];
+                if (!obj._version) {
+                    console.log(self._id + ' wait for ' + obj._id);
+                    obj.once('init', checker);
+                    return;
                 }
-                callback();
             }
-        };
-        this._version ? checker.deliver() : this.on('.state',checker);
+            console.log(self._id + ' ready!');
+            callback();
+        }
+        if (this._version) {
+            console.log(this._id + ' wait for items');
+            checker();
+        } else {
+            console.log(this._id + ' wait for list');
+            this.once('init', checker);
+        }
     }
 
 });

--- a/test/02_EventRelay.js
+++ b/test/02_EventRelay.js
@@ -96,7 +96,7 @@ asyncTest('2.a basic listener func', function (test) {
         equal(huey._lstn.length,2); // only the uplink remains (and the comma)
         start();
     });
-    huey.on('.state', function init2a () {
+    huey.on('.init', function init2a () {
         huey.set({age:1});
     });
 });
@@ -265,7 +265,7 @@ test('2.l partial order', function (test) {
 asyncTest('2.m init push', function (test) {
     env.localhost= host2;
     var scrooge = new Duck({age:105});
-    scrooge.on('.state', function check() {
+    scrooge.on('.init', function check() {
         var tail = storage2.tails[scrooge.spec()];
         // FIXME equal(scrooge._version.substr(1), scrooge._id);
         var op = tail && tail[scrooge._version+'.set'];
@@ -283,7 +283,7 @@ test('2.n local listeners for on/off', function () {
         //triggered by itself, on(init) and host2.on below
         equal(spec.op(), 'on');
     });
-    duck.on('.state',function gotit(){
+    duck.on('.init',function gotit(){
         ok(duck._version);
     });
     duck.on('.reon', function (spec, val) {

--- a/test/03_OnOff.js
+++ b/test/03_OnOff.js
@@ -28,7 +28,7 @@ asyncTest('3.a serialized on, reon', function (){
 
     //downlink.getSources = function () {return [lowerPipe]};
 
-    downlink.on('/Thermometer#room.state',function i(spec,val,obj){
+    downlink.on('/Thermometer#room.init',function i(spec,val,obj){
         obj.set({t:22});
     });
 
@@ -39,7 +39,7 @@ asyncTest('3.a serialized on, reon', function (){
         //downlink.disconnect(lowerPipe);
         start();
         downlink.disconnect();
-    },250);
+    }, 250);
 
 });
 

--- a/test/06_Handshakes.js
+++ b/test/06_Handshakes.js
@@ -100,7 +100,7 @@ asyncTest('6.a Handshake K pattern', function () {
 
     env.localhost = uplink;
     var uprepl = new Mouse({x:3,y:3});
-    downlink.on(uprepl.spec()+'.state',function(sp,val,obj){
+    downlink.on(uprepl.spec()+'.init',function(sp,val,obj){
         //  ? register ~ on ?
         //  host ~ event hub
         //    the missing signature: x.emit('event',value),
@@ -114,7 +114,7 @@ asyncTest('6.a Handshake K pattern', function () {
         equal(obj.x,3);
         equal(obj.y,3);
         equal(obj._version,uprepl._version);
-        // TODO this happens later ok(storage.states[uprepl.spec()]);
+        // TODO this happens later ok(storage..init[uprepl.spec()]);
         start();
     });
     //var dlrepl = downlink.objects[uprepl.spec()];
@@ -168,7 +168,7 @@ asyncTest('6.b Handshake D pattern', function () {
     //  Model.ROTSPAN
     //  Model.COAUTH
 
-    downlink.on('/Mouse#Mickey.state',function(spec,val,obj){
+    downlink.on('/Mouse#Mickey.init',function(spec,val,obj){
         equal(obj._id,'Mickey');
         equal(obj.x,7);
         equal(obj.y,7);
@@ -252,7 +252,7 @@ asyncTest('6.d Handshake R pattern', function () {
     uplink.on(downlink);
     env.localhost = downlink;
 
-    downlink.on('/Mouse#Mickey.state',function(spec,val,dlrepl){
+    downlink.on('/Mouse#Mickey.init',function(spec,val,dlrepl){
         // there is no state in the uplink, dl provided none as well
         ok(!dlrepl.x);
         ok(!dlrepl.y);

--- a/test/08_FileStorage.js
+++ b/test/08_FileStorage.js
@@ -36,7 +36,7 @@ asyncTest('8.a init and save', function(test){
 
     var counter = new Counter('8a');
 
-    counter.on('.state', function () {
+    counter.on('.init', function () {
 
         var spec = counter.set({i:1});
 
@@ -68,7 +68,7 @@ asyncTest('8.b log trimming', function(test){
 
     var counter = new Counter('8b');
 
-    counter.on('.state', function () {
+    counter.on('.init', function () {
 
         var specs = [];
         for(var i=0; i<=storage.MAX_LOG_SIZE; i++) {
@@ -113,7 +113,7 @@ asyncTest('8.c state/log load', function(test){
 
     var counter = new Counter('8c');
 
-    counter.on('.state', function () {
+    counter.on('.init', function () {
 
         var specs = [];
         for(var i=0; i<=storage.MAX_LOG_SIZE; i++) {
@@ -126,7 +126,7 @@ asyncTest('8.c state/log load', function(test){
             var storage2 = new FileStorage('8c');
             var host2 = new Host('counters~8cv2', 0, storage2);
             var counter2 = host2.get(counter.spec());
-            counter2.on('.state', function () {
+            counter2.on('.init', function () {
                 equal(counter2.i,i);
                 start();
             });

--- a/test/mice-stress.js
+++ b/test/mice-stress.js
@@ -54,7 +54,7 @@ if (cluster.isMaster) {
         mice.addObject(mickey);
     });
 
-    mickey.on('.state', function () {
+    mickey.on('.init', function () {
         if (this._version === '!0') {
             mickey.set({
                 x: 100 + (0 | (Math.random() * 100)),


### PR DESCRIPTION
Renamed "state" back to "init" to restore correct alphanumeric order of operations ("init" < "reon")
