### PR TITLE
Pass options through to Einaros websockets.

### DIFF
--- a/lib/EinarosWSStream.js
+++ b/lib/EinarosWSStream.js
@@ -3,13 +3,13 @@
 var env = require('./env');
 var ws_lib = require('ws');
 
-function EinarosWSStream(ws) {
+function EinarosWSStream(ws, opts) {
     var self = this,
         ln = this.lstn = {},
         buf = [];
 
     if (typeof ws === 'string') { // url passed
-        ws = new ws_lib(ws);
+        ws = new ws_lib(ws, opts);
     }
     this.ws = ws;
     if (ws.readyState !== 1/*WebSocket.OPEN*/) {

--- a/lib/Pipe.js
+++ b/lib/Pipe.js
@@ -47,7 +47,7 @@ function Pipe(host, stream, opts) {
             throw new Error('protocol not supported: ' + proto);
         }
         self.url = url;
-        stream = new fn(url);
+        stream = new fn(url, opts);
     }
     self.connect(stream);
 }


### PR DESCRIPTION
Changed this so I could use a self-signed certificate with `wss://`. Here is a code snippet:

```javascript
// CLIENT
swarm_host = new swarm.Host(config.get('swarm.client_id'));
var url = 'wss://' + config.get('swarm.local_server');
var opts = { ca: [pem.server_cert] };
swarm_host.connect(url, opts); // TODO: passing opts.ca requires modifications to Swarm
swarm.env.localhost = swarm_host;
```

```javascript
// SERVER
var https_server = https.createServer({
  cert: pem.server_cert,
  key: pem.server_key,
});
https_server.listen(port, function (err)  {});
var wss_server = new ws.Server({ server: https_server });
wss_server.on('connection', function (ws) {});
```