### PR TITLE
RedisConnection works with default connection params

### DIFF
--- a/lib/RedisStorage.js
+++ b/lib/RedisStorage.js
@@ -43,7 +43,7 @@ RedisStorage.prototype.isRoot = env.isServer;
 var TAIL_FIELD_SUFFIX = ":log";
 
 RedisStorage.prototype.open = function (callback) {
-    var params = this.options.redisConnectParams;
+    var params = this.redisConnectParams;
     if (params.unixSocket) {
         this.db = this.redis.createClient(params.unixSocket, params.options || {});
     } else {


### PR DESCRIPTION
This PR fixes `TypeError: Cannot read property 'unixSocket' of undefined` when `options.redisConnectParams` was left out.