### PR TITLE
Add callback option to handle the quota exceeded error

### DIFF
--- a/lib/SharedWebStorage.js
+++ b/lib/SharedWebStorage.js
@@ -82,7 +82,7 @@ SharedWebStorage.prototype.writeOp = function wsOp(spec, value, src) {
     var tail = this.tails[ti] || (this.tails[ti] = []);
     tail.push(vm);
     var json = JSON.stringify(value);
-    this.store.setItem(spec, json);
+    this._setItem(spec, json);
     if (this.options.trigger) {
         var otherStore = !this.options.persistent ?
             window.localStorage : window.sessionStorage;
@@ -96,7 +96,7 @@ SharedWebStorage.prototype.writeOp = function wsOp(spec, value, src) {
 
 SharedWebStorage.prototype.writeState = function wsPatch(spec, state, src) {
     var ti = spec.filter('/#');
-    this.store.setItem(ti, JSON.stringify(state));
+    this._setItem(ti, JSON.stringify(state));
     var tail = this.tails[ti];
     if (tail) {
         for(var k=0; k<tail.length; k++) {
@@ -124,4 +124,24 @@ SharedWebStorage.prototype.readOps = function (ti, callback) {
         parsed[spec] = JSON.parse(value);
     }
     callback(null, parsed);
+};
+
+SharedWebStorage.prototype._setItem = function (key, value) {
+    try {
+        this._setItem(key, value);
+    }
+    catch (e) {
+        var quotaRegex    = /quota/i;
+        var onStorageFull = this.options &&
+            this.options.onStorageFull;
+
+        if (typeof onStorageFull === "function" &&
+           (quotaRegex.test(e.name) ||
+            quotaRegex.test(e.message) ||
+            e.name === "Error")) {
+
+            // Call callback when storage full
+            onStorageFull();
+        }
+    }
 };


### PR DESCRIPTION
The local storage default size is quite small, when full there needs be some action taken or the data is not further saved. http://chrisberkhout.com/blog/localstorage-errors/