### PR TITLE
Migrate the whole project to parsed specifier

### DIFF
--- a/replica/src/Entry.js
+++ b/replica/src/Entry.js
@@ -63,7 +63,7 @@ EntryState.prototype.toString = function () {
 // while an op is being processed
 function Entry (replica, typeid, state, ops) {
     this.replica = replica;
-    this.typeId = new Spec.Parsed(typeid);
+    this.typeId = new Spec(typeid);
     this.typeid = typeid;
     this.state = state || null;
     // the in-progress op
@@ -91,7 +91,7 @@ Entry.prototype.prependStoredRecords= function (records) {
         if (stamp_pos>0) { // skip tip_stack if any
             key = key.substr(stamp_pos);
         }
-        var spec = new Spec.Parsed(key, typeId);
+        var spec = new Spec(key, typeId);
         return new Op(spec, rec.value, null);
     });
     this.records = ops.concat(this.records);

--- a/replica/src/Replica.js
+++ b/replica/src/Replica.js
@@ -451,7 +451,7 @@ Replica.prototype.handshake = function () {
     if (!this.db_id) { return null; }
     var stamp = this.clock ? this.clock.issueTimestamp() :
         (this.ssn_id||this.user_id||'0');
-    var handshake_spec = new Spec.Parsed('/Swarm+Replica')
+    var handshake_spec = new Spec('/Swarm+Replica')
         .add(this.db_id, '#')
         .add(stamp, '!')
         .add('.on');
@@ -676,7 +676,7 @@ Replica.prototype.removeStream = function (op_stream) {
     if (stamp in this.streams) {
         op_stream.removeAllListeners();
         delete this.streams[stamp];
-        var off = new Spec.Parsed('/Swarm+Replica').add(this.db_id, '#')
+        var off = new Spec('/Swarm+Replica').add(this.db_id, '#')
             .add(op_stream.stamp, '!').add('.off');
         op_stream.end(off);
     }

--- a/syncable/src/Host.js
+++ b/syncable/src/Host.js
@@ -77,7 +77,7 @@ Host.prototype.handshake = function () {
     } else if (this.user_id) {
         stamp = this.user_id;
     }
-    var key = new Spec.Parsed('/Swarm+Host').add(this.db_id||'0', '#')
+    var key = new Spec('/Swarm+Host').add(this.db_id||'0', '#')
         .add(stamp,'!').add('.on');
     return new Op(key, '', this.source);
 };
@@ -95,7 +95,7 @@ Host.prototype.getCRDT = function (obj) {
         }
         return this.crdts[obj.typeid()];
     } else {
-        return this.crdts[new Spec.Parsed(obj).typeid()];
+        return this.crdts[new Spec(obj).typeid()];
     }
 };
 
@@ -320,16 +320,16 @@ Host.prototype.abandonSyncable = function (obj) {
     }
 };
 
-var just_model = new Spec.Parsed('/Model'); // FIXME
+var just_model = new Spec('/Model'); // FIXME
 
 // Retrieve an object by its spec (type and id).
 // Optionally, invoke a callback once the state is actually available.
 Host.prototype.get = function (spec, callback) {
     if (spec.constructor===Function) {
-        spec = new Spec.Parsed('/'+spec._type);
+        spec = new Spec('/'+spec._type);
     }
-    if (spec.constructor!==Spec.Parsed) {
-        spec = new Spec.Parsed(spec.toString(), null, just_model);
+    if (spec.constructor!==Spec) {
+        spec = new Spec(spec.toString(), null, just_model);
     }
     if (!spec.type()) {
         throw new Error('type not specified');

--- a/syncable/src/Op.js
+++ b/syncable/src/Op.js
@@ -20,8 +20,8 @@ function Op (spec, value, source, patch) { // FIXME source -> peer
             patch = orig.patch;
         }
     }
-    this.spec = spec && spec.constructor===Spec.Parsed ?
-        spec : new Spec.Parsed(spec);
+    this.spec = spec && spec.constructor===Spec ?
+        spec : new Spec(spec);
     this.value = value ? value.toString() : '';
     this.source = source ? source.id || source.toString() : '';
     this.patch = patch || null;
@@ -45,7 +45,7 @@ Op.parse = function (str, source, context) {
     Op.reOp.lastIndex = 0;
     var rem = str, m, mm, ops = [], d=0;
     while (m = Op.reOp.exec(rem)) {
-        var spec = new Spec.Parsed(m[1], null, context);
+        var spec = new Spec(m[1], null, context);
         var value = m[2], patch_str = m[3], end = m[4];
         var patch = null;
         if (patch_str) {
@@ -56,7 +56,7 @@ Op.parse = function (str, source, context) {
             patch = [];
             Op.rePatchOp.lastIndex = 0;
             while (mm = Op.rePatchOp.exec(patch_str)) {
-                var op_spec = new Spec.Parsed(mm[1], typeId);
+                var op_spec = new Spec(mm[1], typeId);
                 patch.push(new Op(op_spec, mm[2], source));
             }
         }

--- a/syncable/src/OpStream.js
+++ b/syncable/src/OpStream.js
@@ -68,7 +68,7 @@ function OpStream (stream, options) {
 util.inherits(OpStream, Duplex);
 module.exports = OpStream;
 OpStream.debug = false;
-OpStream.DEFAULT = new Spec.Parsed('/Model!0.on');
+OpStream.DEFAULT = new Spec('/Model!0.on');
 
 OpStream.prototype._write = function (op, encoding, callback) {
     // if (!this.ssn_id) {
@@ -199,7 +199,7 @@ OpStream.prototype.sendHandshake = function (op) {
 //     this.peer_ssn_id = op.origin();
 //     this.peer_options = op.value ? op.patch : null; // TODO
 //     this.peer_stamp = op.stamp();
-//     this.context = new Spec.Parsed('/Model!'+op.stamp()+'.on');
+//     this.context = new Spec('/Model!'+op.stamp()+'.on');
 //
 //     console.warn('context set');
 //     this.emit('id', op, this);

--- a/syncable/src/Set.js
+++ b/syncable/src/Set.js
@@ -46,7 +46,7 @@ Set.prototype.remove = function (syncable) {
 
 
 Set.prototype.contains = function (param) {
-    var typeid = param._type ? param.typeid() : new Spec.Parsed(param).typeid();
+    var typeid = param._type ? param.typeid() : new Spec(param).typeid();
     return typeid in this.objects;
 };
 
@@ -54,7 +54,7 @@ Set.prototype.contains = function (param) {
 //                        V
 
 Set.prototype.get = function (key_spec) {
-    key_spec = new Spec.Parsed(key_spec).filter('/#');
+    key_spec = new Spec(key_spec).filter('/#');
     if (key_spec.pattern() !== '/#') {
         throw new Error("invalid spec");
     }
@@ -107,16 +107,16 @@ function ORSet (state_string) {
         var parsed = JSON.parse(state_string);
         var stamps = Object.keys(parsed).filter(LamportTimestamp.is);
         stamps.forEach(function (stamp) {
-            var spec = new Spec.Parsed(parsed[stamp], null, just_model);
+            var spec = new Spec(parsed[stamp], null, just_model);
             added[stamp] = spec.typeid();
         });
     }
 }
-var just_model = new Spec.Parsed('/Model');
+var just_model = new Spec('/Model');
 
 
 ORSet.prototype.add = function (value, stamp) {
-    var spec = new Spec.Parsed(value,null,just_model);
+    var spec = new Spec(value,null,just_model);
     this.added[stamp] = spec.typeid();
 };
 

--- a/syncable/src/Spec.js
+++ b/syncable/src/Spec.js
@@ -36,127 +36,209 @@ var stamp = require('swarm-stamp');
 //  class Spec to parse them easily. A wrapper is immutable as we pass
 //  specifiers around a lot.
 
-function Spec(str, quant) {
-    if (str && str.constructor === Spec) {
-        this.value = str.value;
+function Spec (spec, scope, defaults) {
+    if (defaults) {
+        if (defaults.constructor!==Spec) {
+            defaults = new Spec(defaults);
+        }
+        this._type = defaults._type;
+        this._id = defaults._id;
+        this._stamp = defaults._stamp;
+        this._op = defaults._op;
     } else {
-        str = (str || '').toString();
-        if (Spec.reSpec.test(str)) {
-            this.value = str;
-        } else if (quant && Spec.reQuant.test(quant) && Spec.reTok.test(str)) {
-            this.value = quant + str;
-        } else {
-            this.value = '';
-            if (str) {
-                throw new Error('malformed spec');
+        this._type = null;
+        this._id = null;
+        this._stamp = null;
+        this._op = null;
+    }
+    if (spec && spec.constructor===Spec) {
+        this._type = spec._type;
+        this._id = spec._id;
+        this._stamp = spec._stamp;
+        this._op = spec._op;
+    } else if (spec) {
+        Spec.reQTokExt.lastIndex = 0;
+        var m, str = spec.toString();
+        while (m = Spec.reQTokExt.exec(str)) {
+            var quant = m[1], tok = m[2];
+            switch (quant) {
+            case '/': this._type = tok; break;
+            case '#': this._id = tok; break;
+            case '!': this._stamp = tok; break;
+            case '.': this._op = tok; break;
             }
         }
     }
+    if (scope) {
+        if (scope.constructor!==Spec) {
+            scope = new Spec(scope);
+        }
+        if (scope._type) { this._type = scope._type; }
+        if (scope._id) { this._id = scope._id; }
+        if (scope._stamp) { this._stamp = scope._stamp; }
+        if (scope._op) { this._op = scope._op; }
+    }
 }
+
 module.exports = Spec;
 
-Spec.prototype.filter = function (quants) {
-    var filterfn = //typeof(quants)==='function' ? quants :
-                function (token, quant) {
-                    return quants.indexOf(quant) !== -1 ? token : '';
-                };
-    return new Spec(this.value.replace(Spec.reQTokExt, filterfn));
+Spec.prototype.toString = function (defaults) {
+    var ret = '';
+    if (this._type) {
+        ret+='/'+this._type;
+    }
+    if (this._id) {
+        ret+='#'+this._id;
+    }
+    if (this._stamp) {
+        ret+='!'+this._stamp;
+    }
+    if (this._op) {
+        ret+='.'+this._op;
+    }
+    return ret;
 };
-Spec.pattern = function (spec) {
-    return spec.toString().replace(Spec.reQTokExt, '$1');
+
+
+Spec.prototype.toAbbrevString = function (defaults) {
+    var ret = '';
+    if (this._type && this._type!==defaults._type) {
+        ret+='/'+this._type;
+    }
+    if (this._id && this._id!==defaults._id) {
+        ret+='#'+this._id;
+    }
+    if (this._stamp && this._stamp!==defaults._stamp) {
+        ret+='!'+this._stamp;
+    }
+    if (this._op && this._op!==defaults._op) {
+        ret+='.'+this._op;
+    }
+    return ret;
 };
-Spec.prototype.isEmpty = function () {
-    return this.value==='';
+
+
+Spec.prototype.type = function () { return this._type; };
+Spec.prototype.Type = function () {
+    return new stamp.LamportTimestamp(this._type);
+};
+Spec.prototype.id = function () { return this._id; };
+Spec.prototype.stamp = function () { return this._stamp; };
+Spec.prototype.version = function () { return '!'+this._stamp; };
+Spec.prototype.op = function () { return this._op; };
+Spec.prototype.typeid = function () {
+    return '/'+this._type+'#'+this._id;
+};
+Spec.prototype.stampop = function () {
+    return '!'+this._stamp+'.'+this._op; // FIXME null values are valid!!!
+};
+Spec.prototype.typeId = function () {
+    var clone = this.clone();
+    clone._stamp = clone._op = null;
+    return clone;
+};
+Spec.prototype.source = function () {
+    if (!this._stamp) {return null;}
+    var parsed = new stamp.LamportTimestamp(this._stamp);
+    return parsed.source();
+};
+Spec.prototype.author = function () {
+    var source = this.source();
+    var i = source.indexOf('~');
+    return i===-1 ? source : source.substring(0,i);
 };
 Spec.prototype.pattern = function () {
-    return Spec.pattern(this.value);
+    return  (this._type?'/':'')+(this._id?'#':'')+
+            (this._stamp?'!':'')+(this._op?'.':'');
 };
+Spec.prototype.set = function (tok, quant) {
+    if (!quant) {
+        if (!tok || tok.charAt(0)>='0') {
+            throw new Error('malformed quant');
+        } // TODO tok syntax check
+        quant = tok.charAt(0);
+        tok = tok.substr(1);
+    }
+    var clone = this.clone();
+    switch (quant) {
+    case '/': clone._type = tok; break;
+    case '#': clone._id = tok; break;
+    case '!': clone._stamp = tok; break;
+    case '.': clone._op = tok; break;
+    }
+    return clone;
+};
+
+Spec.prototype.add = Spec.prototype.set;
+Spec.prototype.setStamp = function (stamp) {
+    var clone = this.clone();
+    clone._stamp = stamp;
+    return clone;
+};
+Spec.prototype.setOp = function (op_name) {
+    var clone = this.clone();
+    clone._op = op_name;
+    return clone;
+};
+Spec.prototype.clone = function () {
+    return new Spec(this);
+};
+
+Spec.inSubtree = function (ssn, parent_ssn) {
+    if (ssn===parent_ssn) { return true; }
+    if (ssn.length<=parent_ssn) { return false; }
+    if (ssn.charAt(parent_ssn.length)!=='~') { return false; }
+    return ssn.substr(0,parent_ssn.length)===parent_ssn;
+};
+
+Spec.prototype.filter = function (quants) {
+    var result = this.clone();
+    if (quants.indexOf('/') < 0) { result._type = null; }
+    if (quants.indexOf('#') < 0) { result._id = null; }
+    if (quants.indexOf('!') < 0) { result._stamp = null; }
+    if (quants.indexOf('.') < 0) { result._op = null; }
+    return result;
+};
+
+
 Spec.prototype.token = function (quant, index) {
-    var at = quant ? this.value.indexOf(quant, this.index) : this.index;
-    if (at === -1) {
+    if (!quant || Spec.quants.indexOf(quant) === -1) {
         return undefined;
     }
-    Spec.reQTokExt.lastIndex = at;
-    var m = Spec.reQTokExt.exec(this.value);
-    this.index = Spec.reQTokExt.lastIndex;
+
+    var value;
+    switch (quant) {
+    case '/': value = this._type; break;
+    case '#': value = this._id; break;
+    case '!': value = this._stamp; break;
+    case '.': value = this._op; break;
+    }
+
+    Spec.reTokExt.lastIndex = 0;
+    var m = Spec.reTokExt.exec(value);
+
     if (!m) {
         return undefined;
     }
-    return {quant: m[1], body: m[2], bare: m[3], ext: m[4]};
+
+    return {quant: quant, body: value, bare: m[1], ext: m[2]};
 };
-Spec.prototype.get = function specGet(quant) {
-    var i = this.value.indexOf(quant);
-    if (i === -1) {
-        return '';
-    }
-    Spec.reQTokExt.lastIndex = i;
-    var m = Spec.reQTokExt.exec(this.value);
-    return m && m[2];
-};
-Spec.prototype.toks = function specGet(quant) {
-    var value = quant ? this.filter(quant).value : this.value;
-    return value.match(Spec.reQTokExt);
-};
-Spec.prototype.tok = function specGet(quant) {
-    var i = this.value.indexOf(quant);
-    if (i === -1) { return ''; }
-    Spec.reQTokExt.lastIndex = i;
-    var m = Spec.reQTokExt.exec(this.value);
-    return m && m[0];
-};
+
 Spec.prototype.has = function specHas(quant) {
-    if (quant.length===1) {
-        return this.value.indexOf(quant) !== -1;
-    } else {
-        var toks = this.value.match(Spec.reQTokExt);
-        return toks.indexOf(quant) !== -1;
-    }
+    var toks = this.pattern();
+    return toks.indexOf(quant) !== -1;
 };
-Spec.prototype.set = function specSet(spec, quant) {
-    var ret = new Spec(spec, quant);
-    var m;
-    Spec.reQTokExt.lastIndex = 0;
-    while (null !== (m = Spec.reQTokExt.exec(this.value))) {
-        if (!ret.has(m[1])) {
-            ret = ret.add(m[0]);
+
+Spec.prototype.fits = function (specFilter) {
+    var myToks = this.toString().match(Spec.reQTokExt);
+    var filterToks = specFilter.match(Spec.reQTokExt), tok;
+    while (tok=filterToks.pop()) {
+        if (myToks.indexOf(tok) === -1) {
+            return false;
         }
     }
-    return ret.sort();
+    return true;
 };
-Spec.prototype.version = function () { return this.get('!'); };
-Spec.prototype.op = function () { return this.get('.'); };
-Spec.prototype.type = function () { return this.get('/'); };
-Spec.prototype.id = function () { return this.get('#'); };
-Spec.prototype.typeid = function () { return this.filter('/#'); };
-// The session that originated the event, author+session id, eg gritzko+123
-Spec.prototype.source = function () {
-    var v = this.get('!');
-    var p = v.indexOf('+');
-    return p===-1 ? '' : v.substr(p+1);
-};
-Spec.prototype.author = function () {
-    var src = this.source();
-    var ai = src.indexOf('~');
-    return ai===-1 ? src : src.substr(0,ai);
-};
-
-Spec.prototype.sort = function () {
-    function Q(a, b) {
-        var qa = a.charAt(0), qb = b.charAt(0), q = Spec.quants;
-        return (q.indexOf(qa) - q.indexOf(qb)) || (a < b);
-    }
-
-    var split = this.value.match(Spec.reQTokExt);
-    return new Spec(split ? split.sort(Q).join('') : '');
-};
-
-Spec.prototype.add = function (spec, quant) {
-    if (spec.constructor !== Spec) {
-        spec = new Spec(spec, quant);
-    }
-    return new Spec(this.value + spec.value);
-};
-Spec.prototype.toString = function () { return this.value; };
 
 /*
 Spec.int2base = function (i, padlen) {
@@ -169,18 +251,6 @@ Spec.int2base = function (i, padlen) {
     }
     return ret;
 };*/
-
-Spec.prototype.fits = function (specFilter) {
-    var myToks = this.value.match(Spec.reQTokExt);
-    var filterToks = specFilter.match(Spec.reQTokExt), tok;
-    while (tok=filterToks.pop()) {
-        if (myToks.indexOf(tok) === -1) {
-            return false;
-        }
-    }
-    return true;
-};
-
 
 Spec.base2int = function (base) {
     var ret = 0, l = base.match(Spec.re64l);
@@ -214,6 +284,7 @@ Spec.reQTokExt = new RegExp(Spec.rsQTokExt, 'g');
 Spec.reSpec = new RegExp('^(?:'+Spec.rsQTokExt+')*$');
 Spec.rsExt = '\\+(=)'.replace(/=/g, Spec.rT);
 Spec.reExt = new RegExp(Spec.rsExt, 'g');
+
 Spec.is = function (str) {
     if (str === null || str === undefined) {
         return false;
@@ -229,238 +300,3 @@ Spec.as = function (spec) {
     }
 };
 
-Spec.Map = function VersionVectorAsAMap(vec) {
-    this.map = {};
-    if (vec) {
-        this.add(vec);
-    }
-};
-Spec.Map.prototype.add = function (versionVector) {
-    var vec = new Spec(versionVector, '!'), tok;
-    while (undefined !== (tok = vec.token('!'))) {
-        var time = tok.bare, source = tok.ext || 'swarm';
-        if (time > (this.map[source] || '')) {
-            this.map[source] = time;
-        }
-    }
-};
-// for each source on either side, keep the lower ts
-Spec.Map.lowerUnion = function (mapB) {
-};
-Spec.Map.prototype.has = function (source) {
-    return source in this.map;
-};
-Spec.Map.prototype.covers = function (version) {
-    Spec.reTokExt.lastIndex = 0;
-    var m = Spec.reTokExt.exec(version);
-    var ts = m[1], src = m[2] || 'swarm';
-    return ts <= (this.map[src] || '');
-};
-Spec.Map.prototype.coversAll = function (vv) {
-    vv = vv.toString();
-    Spec.reTokExt.lastIndex = 0;
-    var m;
-    while (m = Spec.reQTokExt.exec(vv)) { // FIXME
-        var q = m[1], ts = m[2], src = m[3] || 'swarm';
-        if ( q==='!' && ts > (this.map[src] || '') ){
-            return false;
-        }
-    }
-    return true;
-};
-Spec.Map.prototype.maxTs = function () {
-    var ts = null,
-        map = this.map;
-    for (var src in map) {
-        if (!ts || ts < map[src]) {
-            ts = map[src];
-        }
-    }
-    return ts;
-};
-Spec.Map.prototype.minTs = function () {
-};
-// FIXME WTF 'trim' ?!!!!
-Spec.Map.prototype.toString = function (trim) {
-    trim = trim || {top: 10, rot: '0'};
-    var top = trim.top || 10,
-        rot = '!' + (trim.rot || '0'),
-        ret = [],
-        map = this.map;
-    for (var src in map) {
-        ret.push('!' + map[src] + (src === 'swarm' ? '' : '+' + src));
-    }
-    ret.sort().reverse();
-    while (ret.length > top || ret[ret.length - 1] <= rot) {
-        ret.pop();
-    }
-    return ret.join('') || '!0';
-};
-
-
-var stamp = require('swarm-stamp');
-
-//
-//
-function ParsedSpec (spec, scope, defaults) {
-    if (defaults) {
-        if (defaults.constructor!==ParsedSpec) {
-            defaults = new ParsedSpec(defaults);
-        }
-        this._type = defaults._type;
-        this._id = defaults._id;
-        this._stamp = defaults._stamp;
-        this._op = defaults._op;
-    } else {
-        this._type = null;
-        this._id = null;
-        this._stamp = null;
-        this._op = null;
-    }
-    if (spec && spec.constructor===ParsedSpec) {
-        this._type = spec._type;
-        this._id = spec._id;
-        this._stamp = spec._stamp;
-        this._op = spec._op;
-    } else if (spec) {
-        Spec.reQTokExt.lastIndex = 0;
-        var m, str = spec.toString();
-        while (m = Spec.reQTokExt.exec(str)) {
-            var quant = m[1], tok = m[2];
-            switch (quant) {
-            case '/': this._type = tok; break;
-            case '#': this._id = tok; break;
-            case '!': this._stamp = tok; break;
-            case '.': this._op = tok; break;
-            }
-        }
-    }
-    if (scope) {
-        if (scope.constructor!==ParsedSpec) {
-            scope = new ParsedSpec(scope);
-        }
-        if (scope._type) { this._type = scope._type; }
-        if (scope._id) { this._id = scope._id; }
-        if (scope._stamp) { this._stamp = scope._stamp; }
-        if (scope._op) { this._op = scope._op; }
-    }
-}
-Spec.Parsed = ParsedSpec;
-
-
-ParsedSpec.prototype.toString = function (defaults) {
-    var ret = '';
-    if (this._type) {
-        ret+='/'+this._type;
-    }
-    if (this._id) {
-        ret+='#'+this._id;
-    }
-    if (this._stamp) {
-        ret+='!'+this._stamp;
-    }
-    if (this._op) {
-        ret+='.'+this._op;
-    }
-    return ret;
-};
-
-
-ParsedSpec.prototype.toAbbrevString = function (defaults) {
-    var ret = '';
-    if (this._type && this._type!==defaults._type) {
-        ret+='/'+this._type;
-    }
-    if (this._id && this._id!==defaults._id) {
-        ret+='#'+this._id;
-    }
-    if (this._stamp && this._stamp!==defaults._stamp) {
-        ret+='!'+this._stamp;
-    }
-    if (this._op && this._op!==defaults._op) {
-        ret+='.'+this._op;
-    }
-    return ret;
-};
-
-
-ParsedSpec.prototype.type = function () { return this._type; };
-ParsedSpec.prototype.Type = function () {
-    return new stamp.LamportTimestamp(this._type);
-};
-ParsedSpec.prototype.id = function () { return this._id; };
-ParsedSpec.prototype.stamp = function () { return this._stamp; };
-ParsedSpec.prototype.version = function () { return '!'+this._stamp; };
-ParsedSpec.prototype.op = function () { return this._op; };
-ParsedSpec.prototype.typeid = function () {
-    return '/'+this._type+'#'+this._id;
-};
-ParsedSpec.prototype.stampop = function () {
-    return '!'+this._stamp+'.'+this._op; // FIXME null values are valid!!!
-};
-ParsedSpec.prototype.typeId = function () {
-    var clone = this.clone();
-    clone._stamp = clone._op = null;
-    return clone;
-};
-ParsedSpec.prototype.source = function () {
-    if (!this._stamp) {return null;}
-    var parsed = new stamp.LamportTimestamp(this._stamp);
-    return parsed.source();
-};
-ParsedSpec.prototype.author = function () {
-    var source = this.source();
-    var i = source.indexOf('~');
-    return i===-1 ? source : source.substring(0,i);
-};
-ParsedSpec.prototype.pattern = function () {
-    return  (this._type?'/':'')+(this._id?'#':'')+
-            (this._stamp?'!':'')+(this._op?'.':'');
-};
-ParsedSpec.prototype.set = function (tok, quant) {
-    if (!quant) {
-        if (!tok || tok.charAt(0)>='0') {
-            throw new Error('malformed quant');
-        } // TODO tok syntax check
-        quant = tok.charAt(0);
-        tok = tok.substr(1);
-    }
-    var clone = this.clone();
-    switch (quant) {
-    case '/': clone._type = tok; break;
-    case '#': clone._id = tok; break;
-    case '!': clone._stamp = tok; break;
-    case '.': clone._op = tok; break;
-    }
-    return clone;
-};
-ParsedSpec.prototype.add = ParsedSpec.prototype.set;
-ParsedSpec.prototype.setStamp = function (stamp) {
-    var clone = this.clone();
-    clone._stamp = stamp;
-    return clone;
-};
-ParsedSpec.prototype.setOp = function (op_name) {
-    var clone = this.clone();
-    clone._op = op_name;
-    return clone;
-};
-ParsedSpec.prototype.clone = function () {
-    return new ParsedSpec(this);
-};
-
-Spec.inSubtree = function (ssn, parent_ssn) {
-    if (ssn===parent_ssn) { return true; }
-    if (ssn.length<=parent_ssn) { return false; }
-    if (ssn.charAt(parent_ssn.length)!=='~') { return false; }
-    return ssn.substr(0,parent_ssn.length)===parent_ssn;
-};
-
-ParsedSpec.prototype.filter = function (quants) {
-    var result = this.clone();
-    if (quants.indexOf('/') < 0) { result._type = null; }
-    if (quants.indexOf('#') < 0) { result._id = null; }
-    if (quants.indexOf('!') < 0) { result._stamp = null; }
-    if (quants.indexOf('.') < 0) { result._op = null; }
-    return result;
-};

--- a/syncable/src/Syncable.js
+++ b/syncable/src/Syncable.js
@@ -158,7 +158,7 @@ Syncable.removeReaction = function (handle) {
 
 
 Syncable.prototype.spec = function () {
-    return new Spec.Parsed('/' + this._type + '#' + this._id);
+    return new Spec('/' + this._type + '#' + this._id);
 };
 
 
@@ -233,7 +233,7 @@ Syncable.reFieldName = /^[a-z][a-z0-9]*([A-Z][a-z0-9]*)*$/;
 
 Syncable.getType = function (type_id) {
     if (Spec.is(type_id)) {
-        return Syncable.types[new Spec.Parsed(type_id).type()] || undefined;
+        return Syncable.types[new Spec(type_id).type()] || undefined;
     } else {
         return Syncable.types[type_id] || undefined;
     }

--- a/syncable/test/01_Spec.js
+++ b/syncable/test/01_Spec.js
@@ -12,7 +12,7 @@ if (typeof(window)==='object') {
 tape ('syncable.01.b basic specifier syntax', function (tap) {
     var testSpec = '/Class#ID!7Umum+gritzko~ssn.event';
     var spec = new Spec(testSpec);
-    tap.equal(spec.version(),'7Umum+gritzko~ssn');
+    tap.equal(spec.stamp(),'7Umum+gritzko~ssn');
     tap.equal(spec.token('!').ext,'gritzko~ssn');
     tap.equal(spec.source(),'gritzko~ssn');
     tap.equal(spec.author(),'gritzko');
@@ -21,7 +21,7 @@ tape ('syncable.01.b basic specifier syntax', function (tap) {
     var spec2 = new Spec(spec);
     tap.equal(spec.toString(),spec2.toString());
     var def = new Spec('/Type#id!ver.method');
-    var over = def.set('#newid.newmethod');
+    var over = def.set('#newid').set('.newmethod');
     tap.equal(''+over, '/Type#newid!ver.newmethod', 'set() makes a well-formed spec');
     var abc = new Spec('!abc');
     tap.equal(abc.has('!ab'), false); // ?
@@ -31,32 +31,32 @@ tape ('syncable.01.b basic specifier syntax', function (tap) {
 
 
 tape ('syncable.01.b.2 parsed specifier (scopes and defaults)', function (tap) {
-    var spec = new Spec.Parsed('!stamp', '/Type#id', '.on');
+    var spec = new Spec('!stamp', '/Type#id', '.on');
     tap.equal(spec.toString(), '/Type#id!stamp.on', 'scope/default');
     tap.equal(spec.type(), 'Type');
     tap.equal(spec.id(), 'id');
     tap.equal(spec.stamp(), 'stamp');
     tap.equal(spec.op(), 'on');
-    var spec2 = new Spec.Parsed('!stamp2.off',null,spec);
+    var spec2 = new Spec('!stamp2.off',null,spec);
     tap.equal(spec2.toString(), '/Type#id!stamp2.off', 'default (parsed)');
-    var spec3 = new Spec.Parsed('',null,spec);
+    var spec3 = new Spec('',null,spec);
     tap.equal(spec3.toString(), spec.toString());
-    var spec4 = new Spec.Parsed(spec2);
+    var spec4 = new Spec(spec2);
     tap.equal(spec4.toString(), spec2.toString());
 
     var test = '/Type.op2';
-    tap.equal(new Spec.Parsed(test, '/Type!stamp5.op1').toString(), '/Type!stamp5.op1');
-    tap.equal(new Spec.Parsed(test, '/Type!stamp6.op1').toString(), '/Type!stamp6.op1');
-    tap.equal(new Spec.Parsed(test, new Spec.Parsed('/Type!stamp7.op1')).toString(), '/Type!stamp7.op1');
-    tap.equal(new Spec.Parsed(test, null, '/Type!stamp8.op1').toString(), '/Type!stamp8.op2');
-    tap.equal(new Spec.Parsed(test, null, new Spec.Parsed('/Type!stamp9.op1')).toString(), '/Type!stamp9.op2');
+    tap.equal(new Spec(test, '/Type!stamp5.op1').toString(), '/Type!stamp5.op1');
+    tap.equal(new Spec(test, '/Type!stamp6.op1').toString(), '/Type!stamp6.op1');
+    tap.equal(new Spec(test, new Spec('/Type!stamp7.op1')).toString(), '/Type!stamp7.op1');
+    tap.equal(new Spec(test, null, '/Type!stamp8.op1').toString(), '/Type!stamp8.op2');
+    tap.equal(new Spec(test, null, new Spec('/Type!stamp9.op1')).toString(), '/Type!stamp9.op2');
 
-    test = new Spec.Parsed('/Type.op2');
-    tap.equal(new Spec.Parsed(test, '/Type!stamp5.op1').toString(), '/Type!stamp5.op1');
-    tap.equal(new Spec.Parsed(test, '/Type!stamp6.op1').toString(), '/Type!stamp6.op1');
-    tap.equal(new Spec.Parsed(test, new Spec.Parsed('/Type!stamp7.op1')).toString(), '/Type!stamp7.op1');
-    tap.equal(new Spec.Parsed(test, null, '/Type!stamp8.op1').toString(), '/Type.op2');
-    tap.equal(new Spec.Parsed(test, null, new Spec.Parsed('/Type!stamp9.op1')).toString(), '/Type.op2');
+    test = new Spec('/Type.op2');
+    tap.equal(new Spec(test, '/Type!stamp5.op1').toString(), '/Type!stamp5.op1');
+    tap.equal(new Spec(test, '/Type!stamp6.op1').toString(), '/Type!stamp6.op1');
+    tap.equal(new Spec(test, new Spec('/Type!stamp7.op1')).toString(), '/Type!stamp7.op1');
+    tap.equal(new Spec(test, null, '/Type!stamp8.op1').toString(), '/Type.op2');
+    tap.equal(new Spec(test, null, new Spec('/Type!stamp9.op1')).toString(), '/Type.op2');
 
     tap.end();
 });
@@ -67,31 +67,26 @@ tape ('syncable.01.c spec filters', function (tap) {
     tap.equal (new Spec('.off/Class').fits(filter), false);
     tap.equal (new Spec('/Type#id!abc.off.on').fits(filter), true);
 
-    tap.equal (new Spec('/Type#id!abc.on').filter('/').value, '/Type');
-    tap.equal (new Spec('/Type#id!abc.on').filter('#').value, '#id');
-    tap.equal (new Spec('/Type#id!abc.on').filter('!').value, '!abc');
-    tap.equal (new Spec('/Type#id!abc.on').filter('.').value, '.on');
-    tap.equal (new Spec('/Type#id!abc.on').filter('/#').value, '/Type#id');
-
-    tap.equal (new Spec.Parsed('/Type#id!abc.on').filter('/').toString(), '/Type');
-    tap.equal (new Spec.Parsed('/Type#id!abc.on').filter('#').toString(), '#id');
-    tap.equal (new Spec.Parsed('/Type#id!abc.on').filter('!').toString(), '!abc');
-    tap.equal (new Spec.Parsed('/Type#id!abc.on').filter('.').toString(), '.on');
-    tap.equal (new Spec.Parsed('/Type#id!abc.on').filter('/#').toString(), '/Type#id');
+    tap.equal (new Spec('/Type#id!abc.on').filter('/').toString(), '/Type');
+    tap.equal (new Spec('/Type#id!abc.on').filter('#').toString(), '#id');
+    tap.equal (new Spec('/Type#id!abc.on').filter('!').toString(), '!abc');
+    tap.equal (new Spec('/Type#id!abc.on').filter('.').toString(), '.on');
+    tap.equal (new Spec('/Type#id!abc.on').filter('/#').toString(), '/Type#id');
     tap.end();
 });
 
 
 tape ('syncable.01.e corner cases', function (tap) {
     var empty = new Spec('');
-    tap.equal(empty.type()||empty.id()||empty.op()||empty.version(),'');
+    tap.equal(empty.type()||empty.id()||empty.op()||empty.stamp()||'','');
     tap.equal(empty.toString(),'');
     var action = new Spec('.on+re');
     tap.equal(action.op(),'on+re');
     var fieldSet = new Spec('/TodoItem#7AM0f+gritzko!7AMTc+gritzko.set');
     tap.equal(fieldSet.type(),'TodoItem', 'type()');
     tap.equal(fieldSet.id(),'7AM0f+gritzko', 'id()');
-    tap.equal(fieldSet.version(),'7AMTc+gritzko', 'version()');
+    tap.equal(fieldSet.version(),'!7AMTc+gritzko', 'version()');
+    tap.equal(fieldSet.stamp(),'7AMTc+gritzko', 'stamp()');
     tap.equal(fieldSet.op(),'set');
     tap.end();
 });

--- a/syncable/test/04_apart.js
+++ b/syncable/test/04_apart.js
@@ -83,7 +83,7 @@ tape ('syncable.04.B Set CRDT / Syncable', function (t) {
         },
         get: function (spec) {
             return {
-                spec: new Spec.Parsed(spec),
+                spec: new Spec(spec),
                 on:function(ev, sub){
                     t.equal(ev, 'change', 'event name');
                     t.equal(sub, s.onObjectChange, 'subscriber');


### PR DESCRIPTION
Move `Spec.Parsed` -> `Spec`. Consequently `Spec.Parsed` does not exists now.
Managed to get it working, seems pretty easy. I just makes tests passing.
Note that new and old `Spec.version` method returns other result, with _quant_:
```
// was
spec.version() // -> '!7Umum+gritzko~ssn'
// became
spec.version() // -> '7Umum+gritzko~ssn'
```
`Spec#stamp()` method works as preveous version of `Spec#version()` method.