### PR TITLE
Fix bug in UUID compression.

### DIFF
--- a/swarm-ron/src/UUID.js
+++ b/swarm-ron/src/UUID.js
@@ -258,7 +258,7 @@ class UUID {
         } else {
             const t = Base64x64.toZipString(this.time, uuid.time);
             const o = Base64x64.toZipString(this.origin, uuid.origin);
-            const s = Base64x64.RS_PREFIX_SEP.indexOf(o[0])===-1 ? '-' : '';
+            const s = (!t || Base64x64.RS_PREFIX_SEP.indexOf(o[0])===-1) ? '-' : '';
             return t+s+o;
         }
     }

--- a/swarm-ron/test/01_UUID.js
+++ b/swarm-ron/test/01_UUID.js
@@ -125,9 +125,12 @@ tap ('ron.01.E zip', function (tap) {
     const one = UID.fromString("0000000001-origin");
     const two = UID.fromString("0000000002-origin");
     const three = UID.fromString("0000000003-orig");
+    const four = UID.fromString("0000000001-original");
     tap.equal(one.toZipString(two), ")1");
     tap.equal(one.toZipString(one), "");
     tap.equal(three.toZipString(two), ")3(");
+    tap.equal(four.toZipString(one), "-{al"); // REGRESSION: "{al"
+
     tap.end();
 
 });


### PR DESCRIPTION
Hi! I found this bug in the compression of two UUIDs.  If the identifier (timestamp) is equal to the default, the current code only outputs the origin without separator, which is then misparsed as identifier (timestamp). My patch covers the case and adds a test.