### PR TITLE
Lambdafu/bug op compression

### DIFF
--- a/swarm-ron/src/Op.js
+++ b/swarm-ron/src/Op.js
@@ -140,6 +140,7 @@ class Op {
             }
 
             let zip, def, have_prefix=false;
+	    let have_origin=false;
 
             for(let l=0; l<4; l++) {
                 const redef = l===u ? '' : "`\\|/"[l];
@@ -149,6 +150,7 @@ class Op {
                     zip = rezip;
                     have_prefix = redef.length>0 ||
                         (zip.length>0 && Base64x64.PREFIX_SEPS.indexOf(zip[0])!==-1);
+		    have_origin = uid.origin!==def.origin;
                 }
             }
 
@@ -163,7 +165,7 @@ class Op {
             buf += zip;
 
             last_uuid = u;
-            had_origin = uid.origin!==def.origin;
+            had_origin = have_origin;
 
         }
 

--- a/swarm-ron/test/04_Op.js
+++ b/swarm-ron/test/04_Op.js
@@ -67,3 +67,28 @@ tape ('ron.04.B parse values', function (tap) {
     tap.end();
 
 });
+
+
+tape ('ron.04.A compress ops', function (tap) {
+
+    const op = new Op("lww", "a-1", "cdefgh-3", "g-8", "=5");
+    const lop1 = new Op("lww", "b-1", "cdef-3", "g-1", "=10");
+    const lop2 = new Op("lww", "b-1", "cdef-3", "g-9", "=10");
+
+    const op1 = op.toZipString(lop1);
+    tap.equal(op1, '#a@(gh:-8=5');
+
+    const op2 = op.toZipString(lop2);
+    // BUG: '#a(gh:-8=5'
+    tap.equal(op2, '#a@(gh:-8=5');
+
+    const dec_op1 = Op.fromZipString(op1, lop1).toString()
+    tap.equal(dec_op1, '.lww#a-1@cdefgh-3:g-8=5');
+
+    const dec_op2 = Op.fromZipString(op2, lop2).toString()
+    // BUG: '.lww#a-1000gh@cdef-3:g-8=5'
+    tap.equal(dec_op1, dec_op2);  // Invariant.
+
+    tap.end();
+
+});


### PR DESCRIPTION
Hi! I spent some time staring at the compression function, and eventually it occured to me that had_origin dependend only on the location UUID (the value of "def" after the inner loop), and not on any of the other UUIDs.  Which didn't make much sense, so I worked my way backwards to find a test case. If the stars are aligned, separators can be skipped and cause an identifier to be interpreted as origin of the previous UUID.

I was impressed how compact the compression function is and how much it achieves in just a few lines!  Nice work!

To make it easier for testing, I also refactored the decompression function from Frame into the Op class.
